### PR TITLE
add consul connector and add button to scan all consul services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /*-init.clj
 /resources/public/js/compiled
 out
+*.iml
+.idea/

--- a/project.clj
+++ b/project.clj
@@ -11,6 +11,7 @@
                  [metosin/compojure-api "1.1.9"]
                  [day8.re-frame/http-fx "0.1.3"]
                  [ring "1.4.0"]
+                 [consul-clojure "0.1.0"]
                  [cljs-ajax "0.5.8"]]
 
 

--- a/src/clj/sentinel/connector/consul/consul.clj
+++ b/src/clj/sentinel/connector/consul/consul.clj
@@ -1,0 +1,13 @@
+(ns sentinel.connector.consul.consul
+  (:require [consul.core :as consul]))
+
+(defn alive?
+  [serviceID]
+  "Check if a service i alive or not"
+  (contains? (set (keys (consul/agent-checks :local)))
+             (str "service:" serviceID)))
+
+(defn registered-services
+  []
+  "Return all registered service in local consul node"
+  (map #((val %) :ID) (consul/agent-services :local)))

--- a/src/cljs/sentinel/core.cljs
+++ b/src/cljs/sentinel/core.cljs
@@ -19,6 +19,13 @@
   (reagent/render [views/main-panel]
                   (.getElementById js/document "app")))
 
+(defn dispatch-timer-event
+  []
+  (let [now (js/Date.)]
+    (re-frame/dispatch [:refresh-all now])))
+
+(defonce do-timer (js/setInterval dispatch-timer-event 3000))
+
 (defn ^:export init []
   (re-frame/dispatch-sync [:initialize-db])
   (dev-setup)

--- a/src/cljs/sentinel/events.cljs
+++ b/src/cljs/sentinel/events.cljs
@@ -1,6 +1,8 @@
 (ns sentinel.events
   (:require [re-frame.core :as re-frame]
-            [sentinel.db :as db]))
+            [sentinel.db :as db]
+            [cljs.reader :as reader]
+            [ajax.core :refer [GET]]))
 
 
 (re-frame/reg-event-db
@@ -27,10 +29,36 @@
 (re-frame/reg-event-db
   :server-status-success
   (fn [db [_ [server-name status]]]
-    (println "in :server-status-success" server-name status)
+    (println "in :server-status-success and db " server-name status db)
     (assoc-in db [:servers-status server-name] status)))
 
 (re-frame/reg-event-db
   :server-status-error
   (fn [db [_ server-name]]
     (update-in db [:logs] (conj (str server-name "unreachable")))))
+
+(re-frame/reg-event-fx
+  :read-consul
+  (fn []
+    (GET "http://localhost:3450/ping/consul/services"
+         {:handler       (fn [servers]
+                           (doseq [{:keys [server-name status]} (reader/read-string servers)]
+                             (re-frame/dispatch [:add-consul-server [server-name (str "consul/services/" server-name)]])
+                             ))
+          :error-handler #(println "error from /ping/consul/services : " %)
+          })))
+
+(re-frame/reg-event-db
+  :add-consul-server
+  (fn [db [_ [server-name url]]]
+    (update db :servers conj [server-name url])))
+
+(re-frame/reg-event-fx
+  :refresh-all
+  (fn [db]
+    (doseq [[server-name url] (get-in db [:db :servers])]
+      (GET (str "http://localhost:3450/ping/" url)
+           {:handler       (fn [status]
+                             (re-frame/dispatch [:server-status-success [server-name (:status (reader/read-string status))]]))
+            :error-handler #(println "error from /ping/" url " :" %)
+            }))))

--- a/src/cljs/sentinel/views.cljs
+++ b/src/cljs/sentinel/views.cljs
@@ -1,6 +1,7 @@
 (ns sentinel.views
   (:require [re-frame.core :as re-frame]
-            [re-com.core :as re-com]))
+            [re-com.core :as re-com]
+            [reagent.core :as reagent]))
 
 (defn title []
   [re-com/title
@@ -33,6 +34,9 @@
               [re-com/button
                :label "add"
                :on-click #(re-frame/dispatch [:add-server])]
+              [re-com/button
+               :label "@Consul"
+               :on-click #(re-frame/dispatch [:read-consul])]
               ]]
   )
 


### PR DESCRIPTION
Test consul connector : 

1°) Start a consul agent in dev mode (./consul agent -dev). It deploy the consul UI at localhost:8500
2°) Register a service to consul registry, try [consul-clojure "0.1.0"] and execute this sexp (consul/agent-register-service :local {:ID "bank-1" :name "bank kata"  :address "localhost" :port 59220 :check {:http "http://google.fr" :interval "3s" :timeout "5s"}})
3°) TO de-register this same service, try this (consul/agent-deregister-service :local "google")
